### PR TITLE
#10: add missing python dependencies

### DIFF
--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -104,7 +104,7 @@ setup:
         :/opt/vtk/bin\
         :"
     deps:
-      packages: !extend [ *apt-packages, gcc-9, g++-9 ]
+      packages: !extend [ *apt-packages, gcc-9, g++-9, python3-jinja2, python3-pygments]
       cmake: ['3.23.4']
       doxygen: ['1.8.16']
       mpich: { env: { CC: gcc-9, CXX: g++-9 }, args: [ '4.0.2', '-j4' ] }

--- a/ci/shared/scripts/setup-amd64-ubuntu-20.04-gcc-9-cpp.sh
+++ b/ci/shared/scripts/setup-amd64-ubuntu-20.04-gcc-9-cpp.sh
@@ -94,7 +94,7 @@ fi
 
 chmod u+x *.sh
 ls -l
-./packages.sh "curl" "jq" "lcov" "less" "libomp5" "libunwind-dev" "make-guile" "ninja-build" "valgrind" "zlib1g" "zlib1g-dev" "ccache" "python3" "gcc-9" "g++-9"
+./packages.sh "curl" "jq" "lcov" "less" "libomp5" "libunwind-dev" "make-guile" "ninja-build" "valgrind" "zlib1g" "zlib1g-dev" "ccache" "python3" "gcc-9" "g++-9" "python3-jinja2" "python3-pygments"
 ./cmake.sh "3.23.4"
 ./doxygen.sh "1.8.16"
 CC="gcc-9" CXX="g++-9" ./mpich.sh "4.0.2" "-j4"


### PR DESCRIPTION
Add dependencies for documentation builds. This one should finally make magistrate documentation build happy :facepalm: 

fixes #10 