### PR TITLE
#43: upgrade icpx build to 2023

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -60,6 +60,7 @@ jobs:
           TAG=${TAG/11-2-2/11.2.2}
           TAG=${TAG/11-4-3/11.4.3}
           TAG=${TAG/12-2-0/12.2.0}
+          TAG=${TAG/12-9-0/12.9.0}
           docker run \
             --name test-container \
             "lifflander1/vt:wf-$TAG" \

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -302,8 +302,8 @@ setup:
       cmake: ['3.23.4']
       mpich: { env: { CC: icc, CXX: icpc }, args: ['4.0.2', '-j4'] }
 
-  amd64-ubuntu-20.04-icpx-cpp:
-    <<: *amd64-ubuntu-20_04-icpc-icpc-cpp
+  amd64-ubuntu-22.04-icpx-cpp:
+    <<: *amd64-ubuntu-22_04-icpc-icpc-cpp
     label: intel icpx, ubuntu, mpich
     env:
       <<: *intel-icpc-env
@@ -497,10 +497,10 @@ images:
 
   -
     repository: *docker-repository
-    tag: wf-amd64-ubuntu-20.04-icpx-cpp
+    tag: wf-amd64-ubuntu-22.04-icpx-cpp
     arch: linux/amd64
-    base: intel/oneapi:os-tools-ubuntu20.04
-    setup: amd64-ubuntu-20.04-icpx-cpp
+    base: intel/oneapi:os-tools-ubuntu22.04
+    setup: amd64-ubuntu-22.04-icpx-cpp
 
 # List of test configurations available to the CI runners/agents
 runners:
@@ -529,8 +529,8 @@ runners:
 
   -
     type: *runner-types
-    runs-on: ubuntu-20.04
-    image: { repository: *docker-repository, tag: wf-amd64-ubuntu-20.04-icpx-cpp }
+    runs-on: ubuntu-22.04
+    image: { repository: *docker-repository, tag: wf-amd64-ubuntu-22.04-icpx-cpp }
 
   # ubuntu / gcc
   -

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -302,8 +302,8 @@ setup:
       cmake: ['3.23.4']
       mpich: { env: { CC: icc, CXX: icpc }, args: ['4.0.2', '-j4'] }
 
-  amd64-ubuntu-22.04-icpx-cpp:
-    <<: *amd64-ubuntu-22_04-icpc-icpc-cpp
+  amd64-ubuntu-20.04-icpx-cpp:
+    <<: *amd64-ubuntu-20_04-icpc-icpc-cpp
     label: intel icpx, ubuntu, mpich
     env:
       <<: *intel-icpc-env
@@ -497,10 +497,10 @@ images:
 
   -
     repository: *docker-repository
-    tag: wf-amd64-ubuntu-22.04-icpx-cpp
+    tag: wf-amd64-ubuntu-20.04-icpx-cpp
     arch: linux/amd64
-    base: intel/oneapi:os-tools-ubuntu22.04
-    setup: amd64-ubuntu-22.04-icpx-cpp
+    base: intel/oneapi:os-tools-ubuntu20.04
+    setup: amd64-ubuntu-20.04-icpx-cpp
 
 # List of test configurations available to the CI runners/agents
 runners:
@@ -529,8 +529,8 @@ runners:
 
   -
     type: *runner-types
-    runs-on: ubuntu-22.04
-    image: { repository: *docker-repository, tag: wf-amd64-ubuntu-22.04-icpx-cpp }
+    runs-on: ubuntu-20.04
+    image: { repository: *docker-repository, tag: wf-amd64-ubuntu-20.04-icpx-cpp }
 
   # ubuntu / gcc
   -

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -310,7 +310,7 @@ setup:
       cmake: ['3.23.4']
       mpich: { env: { CC: icc, CXX: icpc }, args: ['4.0.2', '-j4'] }
 
-  amd64-ubuntu-20.04-icpx-cpp:
+  amd64-ubuntu-24.04-icpx-cpp:
     <<: *amd64-ubuntu-20_04-icpc-icpc-cpp
     label: intel icpx, ubuntu, mpich
     env:
@@ -512,10 +512,10 @@ images:
 
   -
     repository: *docker-repository
-    tag: wf-amd64-ubuntu-20.04-icpx-cpp
+    tag: wf-amd64-ubuntu-24.04-icpx-cpp
     arch: linux/amd64
-    base: intel/oneapi:os-tools-ubuntu20.04
-    setup: amd64-ubuntu-20.04-icpx-cpp
+    base: intel/oneapi:2026.0.0-devel-ubuntu24.04
+    setup: amd64-ubuntu-24.04-icpx-cpp
 
 # List of test configurations available to the CI runners/agents
 runners:
@@ -544,8 +544,8 @@ runners:
 
   -
     type: *runner-types
-    runs-on: ubuntu-20.04
-    image: { repository: *docker-repository, tag: wf-amd64-ubuntu-20.04-icpx-cpp }
+    runs-on: ubuntu-24.04
+    image: { repository: *docker-repository, tag: wf-amd64-ubuntu-24.04-icpx-cpp }
 
   # ubuntu / gcc
   -

--- a/ci/config.yaml
+++ b/ci/config.yaml
@@ -179,6 +179,14 @@ setup:
     <<: *amd64-ubuntu-20_04-gcc-9-cuda-12_2_0-cpp
     label: nvidia cuda 11.2.2, gcc-9, ubuntu, mpich
 
+  amd64-ubuntu-24.04-gcc-13-cuda-12.9.0-cpp:
+    label: nvidia cuda 12.9.0, gcc-13, ubuntu, mpich
+    env: { <<: *env, CC: gcc-13, CXX: nvcc_wrapper }
+    deps:
+      cmake: ['3.23.4']
+      mpich: { env: { CC: gcc-13, CXX: g++-13 }, args: ['4.0.2', '-j4'] }
+      nvcc_wrapper: ~
+
   # ubuntu / clang
   amd64-ubuntu-20.04-clang-9-cpp:
     label: clang-9, ubuntu, mpich
@@ -402,6 +410,13 @@ images:
     base: nvidia/cuda:11.2.2-devel-ubuntu20.04
     setup: amd64-ubuntu-20.04-gcc-9-cuda-11.2.2-cpp
 
+  -
+    repository: *docker-repository
+    tag: wf-amd64-ubuntu-24.04-gcc-13-cuda-12.9.0-cpp
+    arch: linux/amd64
+    base: nvidia/cuda:12.9.0-devel-ubuntu24.04
+    setup: amd64-ubuntu-24.04-gcc-13-cuda-12.9.0-cpp
+
   # ubuntu / clang
   -
     repository: *docker-repository
@@ -588,6 +603,11 @@ runners:
     type: *runner-types
     runs-on: ubuntu-20.04
     image: { repository: *docker-repository, tag: wf-amd64-ubuntu-20.04-gcc-9-cuda-11.2.2-cpp }
+
+  -
+    type: *runner-types
+    runs-on: ubuntu-24.04
+    image: { repository: *docker-repository, tag: wf-amd64-ubuntu-24.04-gcc-13-cuda-12.9.0-cpp }
 
   # ubuntu / clang
   -

--- a/ci/shared/matrix/azure.json
+++ b/ci/shared/matrix/azure.json
@@ -25,11 +25,11 @@
       "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-icpc-cpp",
       "name": "wf-amd64-ubuntu-20.04-icpc-cpp"
     },
-    "wf-amd64-ubuntu-20-04-icpx-cpp": {
+    "wf-amd64-ubuntu-24-04-icpx-cpp": {
       "label": "intel icpx, ubuntu, mpich",
-      "vmImage": "ubuntu-20.04",
-      "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-icpx-cpp",
-      "name": "wf-amd64-ubuntu-20.04-icpx-cpp"
+      "vmImage": "ubuntu-24.04",
+      "image": "lifflander1/vt:wf-amd64-ubuntu-24.04-icpx-cpp",
+      "name": "wf-amd64-ubuntu-24.04-icpx-cpp"
     },
     "wf-amd64-ubuntu-20-04-gcc-9-cpp": {
       "label": "gcc-9, ubuntu, mpich",

--- a/ci/shared/matrix/azure.json
+++ b/ci/shared/matrix/azure.json
@@ -25,11 +25,11 @@
       "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-icpc-cpp",
       "name": "wf-amd64-ubuntu-20.04-icpc-cpp"
     },
-    "wf-amd64-ubuntu-20-04-icpx-cpp": {
+    "wf-amd64-ubuntu-22-04-icpx-cpp": {
       "label": "intel icpx, ubuntu, mpich",
-      "vmImage": "ubuntu-20.04",
-      "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-icpx-cpp",
-      "name": "wf-amd64-ubuntu-20.04-icpx-cpp"
+      "vmImage": "ubuntu-22.04",
+      "image": "lifflander1/vt:wf-amd64-ubuntu-22.04-icpx-cpp",
+      "name": "wf-amd64-ubuntu-22.04-icpx-cpp"
     },
     "wf-amd64-ubuntu-20-04-gcc-9-cpp": {
       "label": "gcc-9, ubuntu, mpich",

--- a/ci/shared/matrix/azure.json
+++ b/ci/shared/matrix/azure.json
@@ -25,11 +25,11 @@
       "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-icpc-cpp",
       "name": "wf-amd64-ubuntu-20.04-icpc-cpp"
     },
-    "wf-amd64-ubuntu-22-04-icpx-cpp": {
+    "wf-amd64-ubuntu-20-04-icpx-cpp": {
       "label": "intel icpx, ubuntu, mpich",
-      "vmImage": "ubuntu-22.04",
-      "image": "lifflander1/vt:wf-amd64-ubuntu-22.04-icpx-cpp",
-      "name": "wf-amd64-ubuntu-22.04-icpx-cpp"
+      "vmImage": "ubuntu-20.04",
+      "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-icpx-cpp",
+      "name": "wf-amd64-ubuntu-20.04-icpx-cpp"
     },
     "wf-amd64-ubuntu-20-04-gcc-9-cpp": {
       "label": "gcc-9, ubuntu, mpich",

--- a/ci/shared/matrix/azure.json
+++ b/ci/shared/matrix/azure.json
@@ -97,6 +97,12 @@
       "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-gcc-9-cuda-11.2.2-cpp",
       "name": "wf-amd64-ubuntu-20.04-gcc-9-cuda-11.2.2-cpp"
     },
+    "wf-amd64-ubuntu-24-04-gcc-13-cuda-12-9-0-cpp": {
+      "label": "nvidia cuda 12.9.0, gcc-13, ubuntu, mpich",
+      "vmImage": "ubuntu-24.04",
+      "image": "lifflander1/vt:wf-amd64-ubuntu-24.04-gcc-13-cuda-12.9.0-cpp",
+      "name": "wf-amd64-ubuntu-24.04-gcc-13-cuda-12.9.0-cpp"
+    },
     "wf-amd64-ubuntu-20-04-clang-9-cpp": {
       "label": "clang-9, ubuntu, mpich",
       "vmImage": "ubuntu-20.04",

--- a/ci/shared/matrix/github.json
+++ b/ci/shared/matrix/github.json
@@ -27,9 +27,9 @@
     },
     {
       "label": "intel icpx, ubuntu, mpich",
-      "runs-on": "ubuntu-22.04",
-      "image": "lifflander1/vt:wf-amd64-ubuntu-22.04-icpx-cpp",
-      "name": "wf-amd64-ubuntu-22.04-icpx-cpp"
+      "runs-on": "ubuntu-20.04",
+      "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-icpx-cpp",
+      "name": "wf-amd64-ubuntu-20.04-icpx-cpp"
     },
     {
       "label": "gcc-9, ubuntu, mpich",

--- a/ci/shared/matrix/github.json
+++ b/ci/shared/matrix/github.json
@@ -98,6 +98,12 @@
       "name": "wf-amd64-ubuntu-20.04-gcc-9-cuda-11.2.2-cpp"
     },
     {
+      "label": "nvidia cuda 12.9.0, gcc-13, ubuntu, mpich",
+      "runs-on": "ubuntu-24.04",
+      "image": "lifflander1/vt:wf-amd64-ubuntu-24.04-gcc-13-cuda-12.9.0-cpp",
+      "name": "wf-amd64-ubuntu-24.04-gcc-13-cuda-12.9.0-cpp"
+    },
+    {
       "label": "clang-9, ubuntu, mpich",
       "runs-on": "ubuntu-20.04",
       "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-clang-9-cpp",

--- a/ci/shared/matrix/github.json
+++ b/ci/shared/matrix/github.json
@@ -27,9 +27,9 @@
     },
     {
       "label": "intel icpx, ubuntu, mpich",
-      "runs-on": "ubuntu-20.04",
-      "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-icpx-cpp",
-      "name": "wf-amd64-ubuntu-20.04-icpx-cpp"
+      "runs-on": "ubuntu-24.04",
+      "image": "lifflander1/vt:wf-amd64-ubuntu-24.04-icpx-cpp",
+      "name": "wf-amd64-ubuntu-24.04-icpx-cpp"
     },
     {
       "label": "gcc-9, ubuntu, mpich",

--- a/ci/shared/matrix/github.json
+++ b/ci/shared/matrix/github.json
@@ -27,9 +27,9 @@
     },
     {
       "label": "intel icpx, ubuntu, mpich",
-      "runs-on": "ubuntu-20.04",
-      "image": "lifflander1/vt:wf-amd64-ubuntu-20.04-icpx-cpp",
-      "name": "wf-amd64-ubuntu-20.04-icpx-cpp"
+      "runs-on": "ubuntu-22.04",
+      "image": "lifflander1/vt:wf-amd64-ubuntu-22.04-icpx-cpp",
+      "name": "wf-amd64-ubuntu-22.04-icpx-cpp"
     },
     {
       "label": "gcc-9, ubuntu, mpich",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -99,6 +99,17 @@ function "distro-version" {
   result = lookup(item, "distro_version", DISTRO_VERSION)
 }
 
+function "setup-distro-version" {
+  params = [item]
+  result = lookup(
+    item,
+    "setup_distro_version",
+    equal(distro(item), "nvidia/cuda") || equal(distro(item), "intel/oneapi") ?
+      "ubuntu-20.04" :
+      "${distro(item)}-${distro-version(item)}"
+  )
+}
+
 function "compiler" {
   params = [item]
   result = lookup(item, "compiler", COMPILER)
@@ -167,9 +178,7 @@ function "setup-id" {
   params = [item]
   result = join("-", [
     arch(item),
-    equal(distro(item), "nvidia/cuda") || equal(distro(item), "intel/oneapi") ?
-      "ubuntu-20.04" :
-      "${distro(item)}-${distro-version(item)}",
+    setup-distro-version(item),
     compiler(item),
     equal(variant(item), "") ? "cpp" : "${variant(item)}-cpp"
   ])
@@ -439,6 +448,7 @@ target "build-all" {
         compiler = "gcc-13"
         distro = "nvidia/cuda"
         distro_version = "12.9.0-devel-ubuntu24.04"
+        setup_distro_version = "ubuntu-24.04"
         path_prefix = "/opt/nvcc_wrapper/build:"
         variant = "cuda-12.9.0"
         deps = <<EOF
@@ -465,6 +475,7 @@ target "build-all" {
         compiler = "icpx"
         distro = "intel/oneapi"
         distro_version = "2026.0.0-devel-ubuntu24.04"
+        setup_distro_version = "ubuntu-24.04"
         extra_packages = "intel-oneapi-compiler-dpcpp-cpp-2023.2.0"
         ld_library_path = "/opt/intel/oneapi/tbb/latest/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/debugger/10.1.1/dep/lib:/opt/intel/oneapi/debugger/10.1.1/libipt/intel64/lib:/opt/intel/oneapi/debugger/10.1.1/gdb/intel64/lib:/opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/lib/x64:/opt/intel/oneapi/compiler/latest/linux/lib/emu:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/latest/linux/compiler/lib"
         path_prefix = "/opt/intel/oneapi/dev-utilities/latest/bin:/opt/intel/oneapi/compiler/latest/linux/bin/intel64:/opt/intel/oneapi/compiler/latest/linux/bin:"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -464,8 +464,8 @@ target "build-all" {
       {
         compiler = "icpx"
         distro = "intel/oneapi"
-        distro_version = "os-tools-ubuntu20.04"
-        extra_packages = "intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.2.0"
+        distro_version = "os-tools-ubuntu22.04"
+        extra_packages = "intel-oneapi-compiler-dpcpp-cpp-2026.0.0"
         ld_library_path = "/opt/intel/oneapi/tbb/latest/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/debugger/10.1.1/dep/lib:/opt/intel/oneapi/debugger/10.1.1/libipt/intel64/lib:/opt/intel/oneapi/debugger/10.1.1/gdb/intel64/lib:/opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/lib/x64:/opt/intel/oneapi/compiler/latest/linux/lib/emu:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/latest/linux/compiler/lib"
         path_prefix = "/opt/intel/oneapi/dev-utilities/latest/bin:/opt/intel/oneapi/compiler/latest/linux/bin/intel64:/opt/intel/oneapi/compiler/latest/linux/bin:"
         deps = <<EOF

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -463,8 +463,8 @@ target "build-all" {
       # Intel
       {
         compiler = "icpx"
-        distro = "intel-oneapi-hpckit"
-        distro_version = "2024-2-ubuntu22-04"
+        distro = "intel/oneapi"
+        distro_version = "2026.0.0-devel-ubuntu24.04"
         extra_packages = "intel-oneapi-compiler-dpcpp-cpp-2023.2.0"
         ld_library_path = "/opt/intel/oneapi/tbb/latest/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/debugger/10.1.1/dep/lib:/opt/intel/oneapi/debugger/10.1.1/libipt/intel64/lib:/opt/intel/oneapi/debugger/10.1.1/gdb/intel64/lib:/opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/lib/x64:/opt/intel/oneapi/compiler/latest/linux/lib/emu:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/latest/linux/compiler/lib"
         path_prefix = "/opt/intel/oneapi/dev-utilities/latest/bin:/opt/intel/oneapi/compiler/latest/linux/bin/intel64:/opt/intel/oneapi/compiler/latest/linux/bin:"

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -463,9 +463,9 @@ target "build-all" {
       # Intel
       {
         compiler = "icpx"
-        distro = "intel/oneapi"
-        distro_version = "os-tools-ubuntu22.04"
-        extra_packages = "intel-oneapi-compiler-dpcpp-cpp-2026.0.0"
+        distro = "intel/oneapi-hpckit"
+        distro_version = "2024.2-ubuntu22.04"
+        extra_packages = "intel-oneapi-compiler-dpcpp-cpp-2023.2.0"
         ld_library_path = "/opt/intel/oneapi/tbb/latest/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/debugger/10.1.1/dep/lib:/opt/intel/oneapi/debugger/10.1.1/libipt/intel64/lib:/opt/intel/oneapi/debugger/10.1.1/gdb/intel64/lib:/opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/lib/x64:/opt/intel/oneapi/compiler/latest/linux/lib/emu:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/latest/linux/compiler/lib"
         path_prefix = "/opt/intel/oneapi/dev-utilities/latest/bin:/opt/intel/oneapi/compiler/latest/linux/bin/intel64:/opt/intel/oneapi/compiler/latest/linux/bin:"
         deps = <<EOF

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -465,7 +465,7 @@ target "build-all" {
         compiler = "icpx"
         distro = "intel/oneapi"
         distro_version = "os-tools-ubuntu20.04"
-        extra_packages = "intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2022.2.1"
+        extra_packages = "intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-2023.2.0"
         ld_library_path = "/opt/intel/oneapi/tbb/latest/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/debugger/10.1.1/dep/lib:/opt/intel/oneapi/debugger/10.1.1/libipt/intel64/lib:/opt/intel/oneapi/debugger/10.1.1/gdb/intel64/lib:/opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/lib/x64:/opt/intel/oneapi/compiler/latest/linux/lib/emu:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/latest/linux/compiler/lib"
         path_prefix = "/opt/intel/oneapi/dev-utilities/latest/bin:/opt/intel/oneapi/compiler/latest/linux/bin/intel64:/opt/intel/oneapi/compiler/latest/linux/bin:"
         deps = <<EOF

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -463,8 +463,8 @@ target "build-all" {
       # Intel
       {
         compiler = "icpx"
-        distro = "intel/oneapi-hpckit"
-        distro_version = "2024.2-ubuntu22.04"
+        distro = "intel-oneapi-hpckit"
+        distro_version = "2024-2-ubuntu22-04"
         extra_packages = "intel-oneapi-compiler-dpcpp-cpp-2023.2.0"
         ld_library_path = "/opt/intel/oneapi/tbb/latest/env/../lib/intel64/gcc4.8:/opt/intel/oneapi/debugger/10.1.1/dep/lib:/opt/intel/oneapi/debugger/10.1.1/libipt/intel64/lib:/opt/intel/oneapi/debugger/10.1.1/gdb/intel64/lib:/opt/intel/oneapi/compiler/latest/linux/lib:/opt/intel/oneapi/compiler/latest/linux/lib/x64:/opt/intel/oneapi/compiler/latest/linux/lib/emu:/opt/intel/oneapi/compiler/latest/linux/compiler/lib/intel64_lin:/opt/intel/oneapi/compiler/latest/linux/compiler/lib"
         path_prefix = "/opt/intel/oneapi/dev-utilities/latest/bin:/opt/intel/oneapi/compiler/latest/linux/bin/intel64:/opt/intel/oneapi/compiler/latest/linux/bin:"


### PR DESCRIPTION
Fixes #43 

- Update the icpx CI matrix with Ubuntu 24.04 oneAPI image.
- Fix CI Docker image publishing for CUDA 12.9 and Ubuntu 24.04.
